### PR TITLE
Update README for kisskh.nl domain and kkey authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,18 +3,18 @@
 <div align="center">
    <img src="https://i.imgur.com/nhQtOZa.png">
    <br>
-   <strong><i>Simple downloaded for https://kisskh.co/</i></strong>
+   <strong><i>Simple downloader for https://kisskh.nl/</i></strong>
    <br>
    <a href="https://pypi.org/project/kisskh-downloader/">
    <img src="https://img.shields.io/pypi/v/kisskh-downloader?style=for-the-badge">
    </a>
-   <img src="https://img.shields.io/github/actions/workflow/status/Dibakarroy1997/kisskh-dl/pull-request.yml?style=for-the-badge">
+   <img src="https://img.shields.io/github/actions/workflow/status/debakarr/kisskh-dl/pull-request.yml?style=for-the-badge">
    <img src="https://img.shields.io/pypi/dm/kisskh-downloader?style=for-the-badge">
 </div>
 
 ---
 
-👋 Welcome to the kisskh-downloader README! This package is a simple command-line tool for downloading shows from https://kisskh.co/. Here's everything you need to know to get started:
+👋 Welcome to the kisskh-downloader README! This package is a simple command-line tool for downloading shows from https://kisskh.nl/. Here's everything you need to know to get started:
 
 ## 💻 Installation
 
@@ -24,9 +24,23 @@ To install kisskh-downloader, simply run the following command:
 pip install -U kisskh-downloader
 ```
 
+### Playwright (optional)
+
+The site now requires an authentication token (`kkey`) for stream and subtitle APIs. You have two options:
+
+**Option A:** Set `KISSKH_STREAM_KEY` and `KISSKH_SUB_KEY` environment variables (see [Authentication section](#-authentication)).
+
+**Option B:** Install Playwright to generate keys automatically:
+
+```console
+playwright install chromium
+```
+
+---
+
 ## 📚 Usage
 
-After installing the package, you can use the `kisskh dl` command to download shows from the command line.
+### `kisskh dl` — Download episodes
 
 ```console
 kisskh dl --help
@@ -40,58 +54,86 @@ Options:
   -s, --sub-langs TEXT            Languages of the subtitles to download.
   -o, --output-dir TEXT           Output directory where downloaded files will
                                   be store.
+  -ds, --decrypt-subtitle         Decrypt the downloaded subtitle
+  -k, --key TEXT                  Subtitle decryption key (or set KISSKH_KEY
+                                  env var).
+  -iv, --initialization-vector TEXT
+                                  Initialization vector for subtitle
+                                  decryption (or set
+                                  KISSKH_INITIALIZATION_VECTOR env var).
+  --stream-key TEXT               Pre-generated kkey for stream endpoint (or
+                                  set KISSKH_STREAM_KEY env var). Skips
+                                  browser-based kkey generation.
+  --sub-key TEXT                  Pre-generated kkey for subtitle endpoint (or
+                                  set KISSKH_SUB_KEY env var). Skips browser-
+                                  based kkey generation.
   --help                          Show this message and exit.
 ```
 
-Here are some examples:
-
-### 🔗 Direct download entire series in highest quality available in current folder
+#### Download entire series
 
 ```console
-kisskh dl "https://kisskh.co/Drama/Island-Season-2?id=7000" -o .
+kisskh dl "https://kisskh.nl/Drama/Island-Season-2?id=7000" -o .
 ```
 
-![Download all using URL](https://i.imgur.com/cvKYqK3.gif)
-
-
-### 🔍 Search and download entire series in highest quality available in current folder
+#### Search and download
 
 ```console
 kisskh dl "Stranger Things" -o .
-1. Stranger Things - Season 4
-2. Stranger Things - Season 1
-3. Stranger Things - Season 2
-4. Stranger Things - Season 3
-Please select one from above: 1
 ```
 
-![Download all using URL](https://i.imgur.com/mLPqjgj.gif)
-
-### ⬇️ Download specific episodes with specific quality
+#### Download specific episodes with specific quality
 
 > :exclamation: Note that if the selected quality is not available, it will try to get something lower than that quality. If that also is not available, it will try to get the best quality available.
 
 Downloads episode 4 to 8 of `Alchemy of Souls` in 720p:
+
 ```console
-kisskh dl "https://kisskh.co/Drama/Alchemy-of-Souls?id=5043" -f 4 -l 8 -q 720p -o .
+kisskh dl "https://kisskh.nl/Drama/Alchemy-of-Souls?id=5043" -f 4 -l 8 -q 720p -o .
 ```
 
-![Download range of episodes](https://i.imgur.com/Q6697pa.gif)
+Downloads a single episode in 720p:
 
-Downloads episode 3 of `A Business Proposal` in 720p:
 ```console
-kisskh dl "https://kisskh.co/Drama/A-Business-Proposal?id=4608" -f 3 -l 3 -q 720p -o .
+kisskh dl "https://kisskh.nl/Drama/A-Business-Proposal?id=4608" -f 3 -l 3 -q 720p -o .
 ```
 
-![Download single episode](https://i.imgur.com/cNlED8m.gif)
-
-You can also dowload single episode by providing the episode URL
+You can also download a single episode by providing the episode URL:
 
 ```console
-kisskh dl "https://kisskh.co/Drama/A-Business-Proposal/Episode-3?id=4608&ep=86439&page=0&pageSize=100" -o .
+kisskh dl "https://kisskh.nl/Drama/A-Business-Proposal/Episode-3?id=4608&ep=86439&page=0&pageSize=100" -o .
 ```
 
 For more options, use the `--help` flag.
+
+---
+
+### `kisskh get-key` — Generate authentication tokens
+
+The site now requires a `kkey` authentication token. Use `get-key` to generate one from an episode URL:
+
+```console
+kisskh get-key "https://kisskh.nl/Drama/A-Business-Proposal/Episode-1?id=4608&ep=86192&page=0&pageSize=100"
+```
+
+This opens a headless browser to extract the keys, then prints them:
+
+```
+── kkey tokens generated successfully! ──
+
+  Stream key:  <long_hex_string>
+  Sub key:     <long_hex_string>
+
+  To use these without a browser next time, set these env vars:
+
+    set KISSKH_STREAM_KEY=<long_hex_string>
+    set KISSKH_SUB_KEY=<long_hex_string>
+
+  Then run your download command as usual:
+    kisskh dl "https://kisskh.nl/Drama/.../Episode-1?id=1234&ep=5678&page=0&pageSize=100" -o .
+```
+
+---
 
 ### 📖 Decrypting Subtitles
 
@@ -100,7 +142,7 @@ If you want to decrypt the downloaded subtitles, you need to pass the `--decrypt
 Here is an example of how to pass these parameters from the command line:
 
 ```bash
-kisskh download "<drama_url>" --decrypt-subtitle --key "your_key_here" --initialization-vector "your_iv_here"
+kisskh dl "<drama_url>" --decrypt-subtitle --key "your_key_here" --initialization-vector "your_iv_here"
 ```
 
 You can also set these parameters as environment variables. If you set the `KISSKH_KEY` and `KISSKH_INITIALIZATION_VECTOR` environment variables, they will be used by default.
@@ -124,23 +166,36 @@ set KISSKH_INITIALIZATION_VECTOR="your_iv_here"
 After setting these environment variables, you can use the `--decrypt-subtitle` flag without passing the key and initialization vector explicitly:
 
 ```bash
-kisskh download "Drama Name" --decrypt-subtitle
+kisskh dl "Drama Name" --decrypt-subtitle
 ```
-
-Please make sure to replace `"your_key_here"` and `"your_iv_here"` with your actual decryption key and initialization vector.
 
 ---
 
-# 🐞 DEBUG
+## 🔐 Authentication
+
+The site now requires a `kkey` authentication token for stream and subtitle API calls. You have several options:
+
+| Method | How it works |
+|---|---|
+| **Playwright (automatic)** | Installs Chromium and generates keys on-the-fly per episode. Requires: `playwright install chromium` |
+| **Environment variables** | Set `KISSKH_STREAM_KEY` and `KISSKH_SUB_KEY` to skip browser entirely. Generate them once with `kisskh get-key`. |
+
+### All supported environment variables
+
+| Variable | Description | Default |
+|---|---|---|
+| `KISSKH_BASE_URL` | Site base URL | `https://kisskh.nl` |
+| `KISSKH_STREAM_KEY` | Pre-generated kkey for stream endpoint | — |
+| `KISSKH_SUB_KEY` | Pre-generated kkey for subtitle endpoint | — |
+| `KISSKH_KEY` | Subtitle decryption key | — |
+| `KISSKH_INITIALIZATION_VECTOR` | Subtitle decryption IV | — |
+
+---
+
+## 🐞 DEBUG
 
 To enable debugging, use the `-vv` flag while running `kisskh dl`.
 
 ```console
-kisskh -vv dl "https://kisskh.co/Drama/A-Business-Proposal?id=4608" -f 3 -l 3 -q 720p
+kisskh -vv dl "https://kisskh.nl/Drama/A-Business-Proposal?id=4608" -f 3 -l 3 -q 720p
 ```
-
----
-
-# :construction: TODO
-- [ ] Add ability to export all download link
-- [ ] Add ability to open stream in some player


### PR DESCRIPTION
## Summary

Update the README to reflect all recent changes to the project.

## Changes

- **Domain**: All `kisskh.co` references → `kisskh.nl`
- **CLI examples**: Updated URLs and added `--stream-key`/`--sub-key` options
- **New `get-key` command**: Documented how to generate authentication tokens
- **Authentication section**: New section explaining the kkey flow and all supported environment variables
- **Playwright**: Documented optional dependency for automatic key generation
- **Badge fix**: Corrected repo owner in CI badge URL (`Dibakarroy1997` → `debakarr`)
- **Subtitle decrypt**: Fixed example using wrong command (`kisskh download` → `kisskh dl`)
- **TODO section**: Removed (stale items)
- **Installation notes**: Added Playwright browser setup step
