### PR TITLE
Add AnimeStream source module

### DIFF
--- a/src/kisskh_downloader/cli.py
+++ b/src/kisskh_downloader/cli.py
@@ -265,5 +265,99 @@ def get_key(drama_url: str) -> None:
     click.echo("")
 
 
+# ── AnimeStream command group ─────────────────────────────────────────────
+
+
+@kisskh.group(name="anime")
+def anime_group():
+    """Commands for AnimeStream (https://anime.uniquestream.net/)."""
+
+
+@anime_group.command(name="dl")
+@click.argument("content_id")
+@click.option(
+    "--locale",
+    "-l",
+    default="ja-JP",
+    help="Audio language (ja-JP, en-US, etc.)",
+)
+@click.option(
+    "--subs",
+    "-s",
+    default="en-US",
+    help="Hard subtitle language (e.g. en-US, or 'off' for no subs)",
+)
+@click.option(
+    "--output-dir",
+    "-o",
+    default=Path.home() / "Downloads",
+    help="Output directory.",
+)
+def download_episode(content_id: str, locale: str, subs: str, output_dir: Path) -> None:
+    """Download an anime episode from AnimeStream by content ID.
+
+    Example:
+
+        kisskh anime dl sczeR0vi -o .
+    """
+    from kisskh_downloader.downloader import Downloader
+    from kisskh_downloader.sources.animestream import AnimeStreamAPI
+
+    logger = logging.getLogger(__name__)
+
+    api = AnimeStreamAPI()
+
+    # Get content details for filename
+    info = api.content(content_id)
+    series = info.get("series_title", info.get("title", ""))
+    ep = info.get("episode", "0")
+    title = info.get("title", "")
+    logger.info("%s - Episode %s: %s", series, ep, title)
+
+    # Get stream URL
+    sub_locale = subs if subs and subs != "off" else None
+    stream_url = api.get_stream_url(content_id, locale=locale, subtitle_locale=sub_locale)
+    if not stream_url:
+        logger.error("Could not get stream URL for content_id: %s", content_id)
+        return
+
+    logger.info("Stream URL: %s", stream_url[:80])
+
+    # Download
+    safe_series = "".join(c if c.isalnum() or c in " -_" else "_" for c in series).strip()
+    filepath = str(Path(str(output_dir)) / f"{safe_series}_E{ep}")
+
+    downloader = Downloader(referer="https://anime.uniquestream.net/")
+    downloader.download_video_from_stream_url(stream_url, filepath, "best")
+    logger.info("Download complete: %s", filepath)
+
+
+@anime_group.command()
+@click.argument("query")
+def search_anime(query: str) -> None:
+    """Search for anime on AnimeStream."""
+    from kisskh_downloader.sources.animestream import AnimeStreamAPI
+
+    api = AnimeStreamAPI()
+    results = api.search(query)
+    if not results:
+        click.echo("No results found.")
+        return
+    for r in results:
+        click.echo(f"  {r.get('title', '?')}  content_id={r.get('content_id', '?')}")
+
+
+@anime_group.command()
+@click.option("--limit", default=10, help="Number of popular items")
+def popular(limit: int) -> None:
+    """List popular anime on AnimeStream."""
+    from kisskh_downloader.sources.animestream import AnimeStreamAPI
+
+    api = AnimeStreamAPI()
+    results = api.popular(limit=limit)
+    for i, r in enumerate(results, 1):
+        click.echo(f"  {i}. {r.get('title', '?')}  content_id={r.get('content_id', '?')}")
+
+
 if __name__ == "__main__":
     kisskh()

--- a/src/kisskh_downloader/sources/animestream/__init__.py
+++ b/src/kisskh_downloader/sources/animestream/__init__.py
@@ -1,0 +1,9 @@
+"""AnimeStream source module.
+
+AnimeStream (https://anime.uniquestream.net/) is an anime streaming site
+with a clean, open API. No Cloudflare, no encryption.
+"""
+
+from .animestream_api import AnimeStreamAPI
+
+__all__ = ["AnimeStreamAPI"]

--- a/src/kisskh_downloader/sources/animestream/animestream_api.py
+++ b/src/kisskh_downloader/sources/animestream/animestream_api.py
@@ -1,0 +1,86 @@
+"""AnimeStream API client.
+
+Clean, open REST API. No authentication required.
+"""
+
+from __future__ import annotations
+
+import logging
+from urllib.parse import urljoin
+
+import cloudscraper
+
+logger = logging.getLogger(__name__)
+
+API_BASE = "https://anime.uniquestream.net/api/v1"
+
+
+class AnimeStreamAPI:
+    """Client for the AnimeStream API."""
+
+    def __init__(self):
+        self.session = cloudscraper.create_scraper()
+
+    def _get(self, path: str, **params) -> dict:
+        url = urljoin(f"{API_BASE}/", path.lstrip("/"))
+        logger.debug("GET %s", url)
+        resp = self.session.get(url, params=params, timeout=15)
+        resp.raise_for_status()
+        return resp.json()
+
+    def search(self, query: str) -> list[dict]:
+        """Search for anime by title."""
+        data = self._get("videos/search", q=query)
+        return data if isinstance(data, list) else data.get("data", [])
+
+    def popular(self, page: int = 1, limit: int = 20) -> list[dict]:
+        """Get popular anime."""
+        data = self._get("videos/popular", page=page, limit=limit, type="all")
+        return data if isinstance(data, list) else []
+
+    def series(self, series_id: str) -> dict:
+        """Get series details with seasons."""
+        return self._get(f"series/{series_id}")
+
+    def content(self, content_id: str) -> dict:
+        """Get content/episode details."""
+        return self._get(f"content/{content_id}")
+
+    def episode_stream(self, content_id: str, locale: str = "ja-JP") -> dict:
+        """Get HLS streaming URLs for an episode.
+
+        Args:
+            content_id: The episode content ID
+            locale: Audio language (ja-JP, en-US, etc.)
+
+        Returns:
+            Dict with 'hls' containing playlist URL and 'hard_subs'
+        """
+        return self._get(f"episode/{content_id}/media/dash/{locale}")
+
+    def get_stream_url(
+        self, content_id: str, locale: str = "ja-JP", subtitle_locale: str | None = "en-US"
+    ) -> str | None:
+        """Get the best HLS stream URL for an episode.
+
+        Args:
+            content_id: Episode content ID
+            locale: Audio language
+            subtitle_locale: Subtitle language (None for no subs)
+
+        Returns:
+            HLS master playlist URL or None
+        """
+        data = self.episode_stream(content_id, locale)
+        hls = data.get("hls")
+        if not hls:
+            return None
+
+        # If hard subs requested, use that playlist
+        if subtitle_locale and hls.get("hard_subs"):
+            for sub in hls["hard_subs"]:
+                if sub.get("locale") == subtitle_locale:
+                    return sub["playlist"]
+
+        # Fall back to clean audio playlist
+        return hls.get("playlist")


### PR DESCRIPTION
## Summary

Add support for **AnimeStream** (https://anime.uniquestream.net/) — an anime streaming site with a clean, open REST API.

## Why AnimeStream?

Unlike kisskh, cineby, and kaa.lt which all have heavy anti-bot protection (Cloudflare Turnstile, WASM decryption, custom kkey auth, etc.), AnimeStream has **zero protection** on its API. No Cloudflare, no encryption, no tokens needed.

## API Endpoints

| Endpoint | Purpose |
|---|---|
| `GET /api/v1/videos/popular` | Browse popular anime |
| `GET /api/v1/videos/search?q=` | Search anime |
| `GET /api/v1/content/{id}` | Episode metadata |
| `GET /api/v1/episode/{id}/media/dash/{locale}` | HLS stream URLs |
| `GET /api/v1/series/{id}` | Series info with seasons |

Streaming is via `get.mediacache.cc` CDN with signed m3u8 URLs.

## CLI Commands

```bash
# Download an episode by content ID
kisskh anime dl sczeR0vi -o .

# Search for anime
kisskh anime search "Solo Leveling"

# List popular anime
kisskh anime popular
```

## How to find content IDs

Browse https://anime.uniquestream.net/ and look at the watch URL:
`https://anime.uniquestream.net/watch/sczeR0vi/...`

The content ID is the first path segment: `sczeR0vi`.

## Architecture

Follows the same multi-source pattern as the cineby branch:
`src/kisskh_downloader/sources/animestream/`
